### PR TITLE
Update _sidebar_layout.scss

### DIFF
--- a/resources/sass/_sidebar_layout.scss
+++ b/resources/sass/_sidebar_layout.scss
@@ -108,6 +108,7 @@
             .navigation_contain {
                 transform: translateX(-100%);
                 opacity: 0;
+                overflow: hidden;
                 transition: opacity .3s ease, transform .3s ease;
 
                 ul {


### PR DESCRIPTION
Added 'overflow:hidden' to 'navigation_contain' class to prevent vertical and horizontal scroll bars from showing on sidebar on all browsers