### PR TITLE
Make nav bar "sticky"

### DIFF
--- a/resources/sass/_sidebar_layout.scss
+++ b/resources/sass/_sidebar_layout.scss
@@ -104,6 +104,8 @@
             padding: 0 1em;
             width: 15em;
             overflow: auto;
+            position: sticky;
+            top: .65em;
 
             .navigation_contain {
                 transform: translateX(-100%);


### PR DESCRIPTION
Make the navbar sticky to keep it in view at all times when scrolling.

This _may_ be a problem if the window is too short vertically. I would be willing to work on a solution for this (perhaps allowing the nav to be scrollable in that case) but wanted to get opinions on this before investing more work into it.

This does _not_ affect the nav bar when on mobile.