### PR TITLE
fix docs sidebar expanding on each request

### DIFF
--- a/resources/js/docs.js
+++ b/resources/js/docs.js
@@ -2,6 +2,10 @@
 
 require('./vendor/prism.js');
 
+$(document).ready(function () {
+    $('.navigation_contain').show();
+});
+
 var current = $('.docs_sidebar ul').find('li a[href="' + window.location.pathname + '"]');
 
 if (current.length) {

--- a/resources/sass/_sidebar_layout.scss
+++ b/resources/sass/_sidebar_layout.scss
@@ -106,6 +106,7 @@
             overflow: auto;
 
             .navigation_contain {
+                display: none;
                 transform: translateX(-100%);
                 opacity: 0;
                 overflow: hidden;


### PR DESCRIPTION
This PR will fix that the docs sidebar is expanding on each request, happening in google chrome.

![laravelcom-navigation-collapse-after-click](https://user-images.githubusercontent.com/1874088/63368153-9e8ed580-c37d-11e9-9b18-5ef1890fa639.gif)

Hope it's better now.