### PR TITLE
Adjust docs logo alignment

### DIFF
--- a/resources/sass/_sidebar_layout.scss
+++ b/resources/sass/_sidebar_layout.scss
@@ -299,6 +299,7 @@
 
             .logo {
                 padding: 1em 0 1em ;
+                margin-left: -4em;
 
                 .mark {
                     margin-right: 1em;


### PR DESCRIPTION
The homepage flows nicely because the logo is the way it is currently.
Just thought it worth considering the alignment anyways 

| before | after | 
| - | - |
| ![before](https://user-images.githubusercontent.com/29180903/63368910-eb0ded00-c34c-11e9-82cb-ff54a9f1b861.png) | ![after](https://user-images.githubusercontent.com/29180903/63368925-f234fb00-c34c-11e9-8c1f-2dd0e4f674a4.png) |

![page](https://user-images.githubusercontent.com/29180903/63369053-2d372e80-c34d-11e9-9e0f-2727d7c5781e.png)
