### PR TITLE
Updated title tag to match new tagline.

### DIFF
--- a/resources/views/partials/layout.blade.php
+++ b/resources/views/partials/layout.blade.php
@@ -3,7 +3,7 @@
 
 <head>
     <meta charset="utf-8">
-    <title>{{ isset($title) ? $title . ' - ' : null }}Laravel - The PHP Framework For Web Artisans</title>
+    <title>{{ isset($title) ? $title . ' - ' : null }}Laravel - The PHP Framework For Creative Programmers</title>
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
 
     <!-- Favicon -->


### PR DESCRIPTION
The landing page now states "Laravel - The framework for Creative Programmers" not "Web Artisans".