### PR TITLE
Fix: the Telescope link in footer

### DIFF
--- a/resources/sass/_footer.scss
+++ b/resources/sass/_footer.scss
@@ -261,7 +261,7 @@ footer {
         }
         
         .footer_nav_contain {
-            max-height: 32em;
+            max-height: 33em;
         }
     }
     
@@ -287,7 +287,7 @@ footer {
         }
         
         .footer_nav_contain {
-            max-height: 32em;
+            max-height: 33em;
         }
     }
     


### PR DESCRIPTION
The telescope link in the footer is cut, it needs more space so the full word 'Telescope' would be visible
![image](https://user-images.githubusercontent.com/12215673/63389120-a614a580-c3a2-11e9-8e61-a244633cf381.png)
