### PR TITLE
Fixes blurry text in the sidebar

### DIFF
--- a/resources/sass/_sidebar_layout.scss
+++ b/resources/sass/_sidebar_layout.scss
@@ -105,7 +105,7 @@
             width: 15em;
             overflow: auto;
             position: sticky;
-            top: .65em;
+            top: 10px;
 
             .navigation_contain {
                 display: none;


### PR DESCRIPTION
On Google Chrome, Windows 10:

When using the `position: sticky;` style, there's currently a bug that makes the text blurry in the sticky container if the `top` is not a round number of pixels.
This stylesheet uses relative em units which causes the top to be 10.4px. When setting the top to 10px, the text is sharp again!

I've also tested this on Firefox, Edge and IE, where it's not an issue. So far I've only found [this webkit issue](https://bugs.webkit.org/show_bug.cgi?id=159428) that even begins to explain it.