### PR TITLE
Make menu items togglable

### DIFF
--- a/resources/js/docs.js
+++ b/resources/js/docs.js
@@ -15,9 +15,9 @@ if (current.length) {
 }
 
 $(".docs_sidebar h2").click(function (e) {
-    e.preventDefault();
-    $(".navigation_contain ul li").removeClass("sub--on");
-    $(this).parent().addClass("sub--on");
+	this.parentNode.classList.toggle('sub--on')
+	
+	return false
 });
 
 $('#version_switcher').change(function(e){


### PR DESCRIPTION
Currently:

- expanded item closes as soon as you open another (this causes jumping behaviour that's especially undesirable when you open a short sublist that's below a long open one)
- you can't close an expanded item unless you open another

I propose:

- don't close unless explicitly toggled
- allow toggling them open and closed