### PR TITLE
Condense the table of contents

### DIFF
--- a/resources/sass/_docs.scss
+++ b/resources/sass/_docs.scss
@@ -336,7 +336,7 @@
 
     li {
         display: block;
-        margin-bottom: 1.25em;
+        margin-bottom: .25em;
 
         a {
             position: relative;
@@ -354,7 +354,7 @@
     }
 
     ul {
-        margin-top: 1.25em;
+        margin-top: .25em;
         padding: 0;
         margin-bottom: 0;
 


### PR DESCRIPTION
This makes more of the TOC to be visible at once and brings the actual content closer.

Currently it's okay for pages with a short TOC, but in some cases I have to scroll quite far across spread out items to reach the actual content https://laravel.com/docs/5.8/eloquent 