### PR TITLE
Make menu scrollable on desktop

### DIFF
--- a/resources/sass/_sidebar_layout.scss
+++ b/resources/sass/_sidebar_layout.scss
@@ -285,12 +285,12 @@
         }
 
         .sidebar {
-            display: block;
             overflow: visible;
-            position: relative;
+            position: sticky;
+            top: 0;
             background: none;
-            flex: none;
-            width: 15em; height: auto;
+            width: 15em; 
+            height: 100vh;
 
             &::before {
                 content: "";


### PR DESCRIPTION
`position: sticky; top: 0;` is my quick hack to make `.sidebar` fixed without taking it out of flow. I am not that great at CSS but I feel this is a bit of emergency as some chapters are pretty hard to access on a small screen.

![image](https://user-images.githubusercontent.com/16481303/63397260-afb60180-c3d2-11e9-88e5-7ece614d8f13.png)

I have to zoom out to 67% to reach bottom of "Digging Deeper" at the current design. But other people might not guess that there's anything below and wouldn't even try zooming out.