### PR TITLE
Condense sidebar menu

### DIFF
--- a/resources/sass/_sidebar_layout.scss
+++ b/resources/sass/_sidebar_layout.scss
@@ -120,7 +120,7 @@
 
                     li {
                         display: block;
-                        padding: .65em 0;
+                        padding: .4em 0;
 
                         h2{
                             display: block;
@@ -172,14 +172,10 @@
                         }
                     }
 
-                    li.sub--on {
-                        &> h2 {
-                            margin-bottom: 1em;
-                        }
-
-                        ul {
-                            max-height: 28em;
-                        }
+                    li.sub--on ul {
+                        max-height: 28em;
+                        margin-top: .4em;
+                        margin-bottom: -.4em;
                     }
                 }
             }


### PR DESCRIPTION
One more opinionated from me. Reduce padding by a third to take up less screen estate. I tried to leave enough padding so the individual links would still be accessible using thumb.