### PR TITLE
Fix footer sections display on mobile

### DIFF
--- a/resources/sass/_footer.scss
+++ b/resources/sass/_footer.scss
@@ -232,6 +232,7 @@ footer {
     .footer_nav_contain {
         max-height: 0;
         transition: max-height .4s ease;
+        display: none;
         
         ul {
             list-style-type: none;
@@ -261,6 +262,7 @@ footer {
         
         .footer_nav_contain {
             max-height: 33em;
+            display: block;
         }
     }
     
@@ -287,6 +289,7 @@ footer {
         
         .footer_nav_contain {
             max-height: 33em;
+            display: block;
         }
     }
     


### PR DESCRIPTION
When viewing the site on mobile the footer text isn't hidden. I've made two videos to demonstrate the problem and what my changes do.

Current issue: https://d.pr/v/gsTz1G

With proposed changes: https://d.pr/v/qt1ZtF