### PR TITLE
Remove the Learn More button under Resources

### DIFF
--- a/resources/views/marketing.blade.php
+++ b/resources/views/marketing.blade.php
@@ -229,7 +229,6 @@
                                     <li><a href="https://laracasts.com/discuss">Forums</a></li>
                                     <li><a href="https://certification.laravel.com/">Certification</a></li>
                                 </ul>
-                                <a href="#" class="btn"><span>Learn More</span></a>
                             </div>
 
                             <div class="featured_resource">


### PR DESCRIPTION
# Summary

Right now, the **Learn More** button under **Resources** on the homepage (`marketing`) doesn't go anywhere.

Until a resources detail page is added, the button can be removed.

Let me know if you'd like this done differently or have any feedback. Thanks!