### PR TITLE
Increase desktop font size for docs

### DIFF
--- a/resources/sass/_docs.scss
+++ b/resources/sass/_docs.scss
@@ -34,7 +34,6 @@
         .docs_main {
             flex: 1;
             min-width: 0;
-            max-width: 42em;
         }
     }
 
@@ -98,9 +97,9 @@
     }
 
     code {
-        font-size: .75em;
+        font-size: 1.2em;
         font-weight: 400;
-        line-height: 1.9em;
+        line-height: 1.5em;
         color: $black;
     }
 
@@ -149,7 +148,7 @@
 
     @include fl-break(55em) {
         p {
-            font-size: .94em;
+            font-size: 1.2em;
         }
 
         ul:not(:first-of-type), .content-list ul {


### PR DESCRIPTION
| before | after |
| - | -  |
| ![before](https://user-images.githubusercontent.com/29180903/63457856-b9b22180-c41f-11e9-8084-ae2bd40c198e.png) | ![after](https://user-images.githubusercontent.com/29180903/63457869-bdde3f00-c41f-11e9-897c-c10bcf5362dc.png)

I normally cmd + to 120% anyways.. so maybe its just my bad eyes 👀 
But incase you think font size could be a tad larger too