### PR TITLE
Remove logotype

### DIFF
--- a/resources/views/partials/layout.blade.php
+++ b/resources/views/partials/layout.blade.php
@@ -47,9 +47,6 @@
         <div class="footer_bg">
             <div class="contain">
                 <div class="footer_content">
-                    <div class="logotype">
-                        <img src="/img/logotype.min.svg" alt="Laravel">
-                    </div>
                     <div class="search_box">
 
                     </div>


### PR DESCRIPTION
This is a cheeky PR.

The logotype is the single piece of the new website that doesn't make sense or fit. Everything else is 10/10 but then there's this huge logotype which is out of place.

<img width="1437" alt="Screen Shot 2019-08-21 at 9 51 00 PM" src="https://user-images.githubusercontent.com/537943/63482242-cce3e200-c45d-11e9-8dc8-0e38c8013f97.png">
