### PR TITLE
Increase docs paragraph font size to 1rem

### DIFF
--- a/resources/sass/_docs.scss
+++ b/resources/sass/_docs.scss
@@ -105,7 +105,7 @@
     }
 
     p {
-        font-size: 0.94em;
+        font-size: 1rem;
         line-height: 1.8em;
 
         code {
@@ -149,7 +149,7 @@
 
     @include fl-break(55em) {
         p {
-            font-size: .94em;
+            font-size: 1rem;
         }
 
         ul:not(:first-of-type), .content-list ul {


### PR DESCRIPTION
It is really hard to read the docs when compared with the previous.
The generally accepted UX principle is to have 1 rem font size at least for paragraph.