### PR TITLE
Reduce hover animation jenkiness in header nav

### DIFF
--- a/resources/sass/_header.scss
+++ b/resources/sass/_header.scss
@@ -253,7 +253,7 @@ nav.main {
                 }
 
                 &:hover {
-                    transform: scale(1.03);
+                    transform: perspective(1px) scale3d(1.03, 1.03, 1.03);
                 }
             }
 


### PR DESCRIPTION
Similar to #42 , the `scale(1.03)` hover animation in the main header nav looks jenky in webkit browsers.

This pull request changes `scale` to `scale3d` and adds `perspective(1px)` to smooth the animation more. The text is slightly blurred in the hover state but I don't believe there's a fix for that.

Demo:
https://giphy.com/gifs/cM7burmgPSZslfFEcI