### PR TITLE
Fix version switcher

### DIFF
--- a/resources/views/docs.blade.php
+++ b/resources/views/docs.blade.php
@@ -34,7 +34,7 @@
                                 <div class="custom_select">
                                     <select id="version_switcher">
                                         @foreach ($versions as $key => $display)
-                                            <option {{$currentVersion == $key ? 'selected="yes"' : ''}}" value="{{ url('docs/'.$key.$currentSection) }}">{{ $display }}</option>
+                                            <option {{ $currentVersion == $key ? 'selected' : '' }} value="{{ url('docs/'.$key.$currentSection) }}">{{ $display }}</option>
                                         @endforeach
                                     </select>
                                 </div>


### PR DESCRIPTION
HTML was invalid due to a useless quote, plus `selected="yes"` is not valid, it should be either `selected` or `selected="selected"`.

**Before:**

<img width="564" alt="Screen Shot 2019-08-23 at 12 45 33" src="https://user-images.githubusercontent.com/356978/63587465-63bab680-c5a4-11e9-919a-3755bd7cea7d.png">

**After:**

<img width="568" alt="Screen Shot 2019-08-23 at 12 45 40" src="https://user-images.githubusercontent.com/356978/63587474-67e6d400-c5a4-11e9-8b04-8dfbbbb9ba9f.png">
