### PR TITLE
Fix scroll behaviour on Safari when using touch

### DIFF
--- a/resources/sass/_header.scss
+++ b/resources/sass/_header.scss
@@ -207,6 +207,7 @@ nav.main {
     .nav_contain {
         max-height: 0;
         overflow: scroll;
+        -webkit-overflow-scrolling: touch;
         opacity: 0;
         padding: 0 5.5%;
         transform: translateY(-2em);

--- a/resources/sass/_prism.scss
+++ b/resources/sass/_prism.scss
@@ -50,6 +50,7 @@ pre[class*="language-"] {
 	padding: 1em;
 	margin: .5em 0 2em;
 	overflow: auto;
+	-webkit-overflow-scrolling: touch;
     max-width: 100%;
 }
 

--- a/resources/sass/_sidebar_layout.scss
+++ b/resources/sass/_sidebar_layout.scss
@@ -104,6 +104,7 @@
             padding: 0 1em;
             width: 15em;
             overflow: auto;
+            -webkit-overflow-scrolling: touch;
             position: sticky;
             top: 10px;
 


### PR DESCRIPTION
WebKit based browsers require the vendor-specific CSS `-webkit-overflow-scrolling: touch;` in order for scrolling overflow to be given the ‘native’ inertial scroll behaviour on touchscreen devices (i.e. any browser running on iOS). Without it, scrolling stops the second the touch ends, which feels very unnatural and makes scrolling long lists difficult.

A couple of comparison videos to make it easier to illustrate:

**Front page menu dropdown**
[Before](https://imgur.com/a/MEwOVd1)

[After](https://imgur.com/a/pNnN9Bv)

**Docs sidebar**
[Before](https://imgur.com/a/WdLTIVz)

[After](https://imgur.com/a/HrEWhix)