### PR TITLE
Fix selection on callout image

### DIFF
--- a/resources/sass/_docs.scss
+++ b/resources/sass/_docs.scss
@@ -217,6 +217,7 @@
             top: 50%; left: 50%;
             transform: translate(-50%, -50%);
             opacity: .7;
+            user-select: none;
         }
 
         &.blue { background: $blue; }


### PR DESCRIPTION
At the moment, when selecting the callout text, the image gets highlighted too:

![Example screenshot](https://i.imgur.com/L7CGpFM.png)

PR fixes this behaviour