### PR TITLE
Minor readability improvement

### DIFF
--- a/resources/sass/_docs.scss
+++ b/resources/sass/_docs.scss
@@ -156,7 +156,7 @@
             display: block;
             padding-left: 1.25em;
             margin-bottom: 1rem;
-            font-size: .80em;
+            font-size: .89em;
             color: rgba($black, .7);
             line-height: 1.714em;
 

--- a/resources/sass/_typography.scss
+++ b/resources/sass/_typography.scss
@@ -155,7 +155,6 @@ p, ul, ol {
 
     a {
         color: $red;
-        text-decoration: underline;
 
         &:hover {
             color: darken($red, 10%);


### PR DESCRIPTION
The underlining of the links at the top of the docs page is hard to read. I think it's mostly due to the underlined text combined with the font style. Removing the underline works out well.

I also found it to be too small relative to the new 1rem font size pushed in pr #47 

**Before:**
[https://i.imgur.com/NAecmQZ.jpg](https://i.imgur.com/NAecmQZ.jpg)

**After:**
[https://i.imgur.com/eJTtDBo.jpg](https://i.imgur.com/eJTtDBo.jpg)