### PR TITLE
Remove underline only from .content-list ul, bump font size to match.

### DIFF
--- a/resources/sass/_docs.scss
+++ b/resources/sass/_docs.scss
@@ -156,9 +156,13 @@
             display: block;
             padding-left: 1.25em;
             margin-bottom: 1rem;
-            font-size: .80em;
+            font-size: .89em;
             color: rgba($black, .7);
             line-height: 1.714em;
+
+            a {
+                text-decoration: none;
+            }
 
             code {
                 font-size: .875em;


### PR DESCRIPTION
Same goal as PR #64. Changed removal of the underline to only target the unordered list in the .content-list on the docs page instead.

Here's a few screenshots.

![Screen Shot 2019-08-29 at 7 36 49 AM](https://user-images.githubusercontent.com/1581075/63949874-e376d400-ca2f-11e9-8faa-c946312a398d.png)
![Screen Shot 2019-08-29 at 7 37 08 AM](https://user-images.githubusercontent.com/1581075/63949877-e40f6a80-ca2f-11e9-91ac-d2d0fdb4fb7c.png)

