### PR TITLE
Make search input show anywhere on keypress

### DIFF
--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -54,4 +54,14 @@ $(document).ready(function () {
         var anchor = $('<a href="#' + this.name + '"/>');
         $(this).parent().next().wrapInner(anchor);
     });
+
+    $(this).on('keyup', function(event){
+        var searchInput = $("#search-docs-input");
+        if (event.isComposing || event.keyCode === 229) {
+            return;
+        }
+        if (event.key.toLocaleLowerCase() === "s" && !searchInput.focus()) {
+            searchInput.focus();
+        }
+    });
 });


### PR DESCRIPTION
When a user has scrolled past where the search box is visible, they have to scroll back up to perform a search on the landing page and documentation page. 

Now with the press of `S`, they can `focus` the search box from anywhere

####
Demo

![chrome-capture](https://user-images.githubusercontent.com/12516195/64070538-43e95980-cc5a-11e9-9c8a-4bd0712376bf.gif)
