### PR TITLE
Removed Mousetrap dependency as it is used only for a single key binding

### DIFF
--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -6,7 +6,11 @@ $(document).ready(function () {
         $(".bar").toggleClass("animate");
     });
 
-    Mousetrap.bind('/', function (e) {
+    $(document).on('keydown', function(e) {
+        var slashKey = e.key === '/' || e.which === 191 || e.keyCode === 191;
+        if (!slashKey) {
+            return;
+        }
         e.preventDefault();
         $(".header_content .search_box").addClass("search--on");
         $('#search-docs-input').focus();

--- a/resources/views/partials/layout.blade.php
+++ b/resources/views/partials/layout.blade.php
@@ -25,7 +25,6 @@
 
     <!-- Load JS -->
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.0/jquery.min.js"></script>
-    <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/mousetrap/1.4.6/mousetrap.min.js"></script>
 
 </head>
 <body class="language-php">


### PR DESCRIPTION
Mousetrap is a great library, but I do not see the point to include it if is used only for a single key binding.
This PR saves ~2KB and a network request.