### PR TITLE
Add line height to docs sidebar a tags

### DIFF
--- a/resources/sass/_sidebar_layout.scss
+++ b/resources/sass/_sidebar_layout.scss
@@ -161,6 +161,7 @@
                                 position: relative;
                                 padding-left: 1em;
                                 font-weight: 400;
+                                line-height: 1.25;
                             }
 
                             &.active a::before {


### PR DESCRIPTION
This fixes a visual bug in Firefox Dev Edition (70.0b2 64-bit) on macOS.

The same line height in Chrome appears fine as well. There was a bit of overflow in FF and the last item in a sidebar list was cut off.