### PR TITLE
Improve scrolling on webkit mobile devices

### DIFF
--- a/resources/sass/_base.scss
+++ b/resources/sass/_base.scss
@@ -26,7 +26,11 @@ html, body {
 	width: 100%; height: 100%;
 	margin: 0;
 	padding: 0;
-	overflow-x: hidden;
+}
+
+body {
+    overflow-x: hidden;
+    -webkit-overflow-scrolling: touch;
 }
 
 .page_contain {


### PR DESCRIPTION
Add webkit-overflow-scrolling: touch to fix scrolling issues on touch devices

This fixes this issue: https://twitter.com/joseph_silber/status/1168933957305544704