### PR TITLE
Fix sidebar sections with too many items

### DIFF
--- a/resources/sass/_sidebar_layout.scss
+++ b/resources/sass/_sidebar_layout.scss
@@ -180,7 +180,7 @@
                         }
 
                         ul {
-                            max-height: 28em;
+                            max-height: none;
                         }
                     }
                 }


### PR DESCRIPTION
With the old `max-height: 28em;` a sidebar section of the documentation with too many items (in my test setup, over 12) wouldn't display all of the items.

Removing the max height on the opened UL element fixes it.

Live example of the issue fixed by this commit : 

https://laravel.com/docs/5.1/mail