### PR TITLE
Fixed link to Horizon in Ecosystem dropdown

### DIFF
--- a/resources/views/marketing.blade.php
+++ b/resources/views/marketing.blade.php
@@ -106,7 +106,7 @@
                                     </a>
                                 </li>
                                 <li class="sys_horizon">
-                                    <a href="https://horizon.laravel.com">
+                                    <a href="/docs/{{DEFAULT_VERSION}}/horizon">
                                         <div class="system_icon"><img src="/img/ecosystem/horizon.min.svg" alt="Icon">
                                         </div>
                                         <div class="system_info">Horizon <span>Queue Monitoring</span></div>

--- a/resources/views/partials/header.blade.php
+++ b/resources/views/partials/header.blade.php
@@ -41,7 +41,7 @@
                                         </a>
                                     </li>
                                     <li class="sys_horizon">
-                                        <a href="https://horizon.laravel.com/">
+                                        <a href="/docs/{{DEFAULT_VERSION}}/horizon">
                                             <div class="system_icon">
                                                 <img src="/img/ecosystem/horizon.min.svg" alt="Icon">
                                             </div>

--- a/resources/views/partials/layout.blade.php
+++ b/resources/views/partials/layout.blade.php
@@ -121,7 +121,7 @@
                                     <li><a href="https://vapor.laravel.com">Vapor</a></li>
                                     <li><a href="https://forge.laravel.com">Forge</a></li>
                                     <li><a href="https://envoyer.io">Envoyer</a></li>
-                                    <li><a href="https://horizon.laravel.com">Horizon</a></li>
+                                    <li><a href="/docs/{{DEFAULT_VERSION}}/horizon">Horizon</a></li>
                                     <li><a href="https://lumen.laravel.com">Lumen</a></li>
                                     <li><a href="https://nova.laravel.com">Nova</a></li>
                                     <li><a href="/docs/{{DEFAULT_VERSION}}/broadcasting">Echo</a></li>


### PR DESCRIPTION
Currently, in the 'Ecosystem' dropdown and when you click on the one for Horizon it goes to `horizon.laravel.com` which just redirects to the `laravel.com` homepage. 

I've updated this so that it now links to Horizon's documentation page.