### PR TITLE
Remove index.php from URL

### DIFF
--- a/app/Providers/RouteServiceProvider.php
+++ b/app/Providers/RouteServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace App\Providers;
 
+use Illuminate\Support\Str;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Foundation\Support\Providers\RouteServiceProvider as ServiceProvider;
 
@@ -35,6 +36,8 @@ class RouteServiceProvider extends ServiceProvider
      */
     public function map()
     {
+        $this->removeIndexPhpFromUrl();
+        
         $this->mapApiRoutes();
 
         $this->mapWebRoutes();
@@ -69,5 +72,22 @@ class RouteServiceProvider extends ServiceProvider
              ->middleware('api')
              ->namespace($this->namespace)
              ->group(base_path('routes/api.php'));
+    }
+    
+    /**
+     * This will remove the index.php from the URL and prevent canonical conflicts.
+     *
+     * @return void
+     */
+    protected function removeIndexPhpFromUrl()
+    {
+        if (Str::contains(request()->getRequestUri(), '/index.php/')) {
+            $url = str_replace('index.php/', '', request()->getRequestUri());
+
+            if (strlen($url) > 0) {
+                header("Location: $url", true, 301);
+                exit;
+            }
+        }
     }
 }


### PR DESCRIPTION
Removes index.php from the URL's (see https://github.com/laravel/framework/issues/30398 for more information about why this happens)

Fix from @mattiasgeniar: https://github.com/laravel/framework/issues/30398#issuecomment-556310025