### PR TITLE
Better 404s

### DIFF
--- a/app/Documentation.php
+++ b/app/Documentation.php
@@ -100,6 +100,22 @@ class Documentation
         );
     }
 
+
+    /**
+     * Determine which versions a section exists in
+     *
+     * @param string $page
+     *
+     * @return \Illuminate\Support\Collection
+     */
+    public function sectionExistsInVersions($page)
+    {
+        return collect(self::getDocVersions())
+            ->filter(function ($version) use ($page) {
+                return $this->sectionExists($version, $page);
+            });
+    }
+
     /**
      * Get the publicly available versions of the documentation
      *

--- a/app/Http/Controllers/DocsController.php
+++ b/app/Http/Controllers/DocsController.php
@@ -56,13 +56,18 @@ class DocsController extends Controller
         $content = $this->docs->get($version, $sectionPage);
 
         if (is_null($content)) {
+            $otherVersions = $this->docs->sectionExistsInVersions($page);
+
             return response()->view('docs', [
                 'title' => 'Page not found',
                 'index' => $this->docs->getIndex($version),
-                'content' => view('docs-missing'),
+                'content' => view('docs-missing', [
+                    'otherVersions' => $otherVersions,
+                    'page' => $page,
+                ]),
                 'currentVersion' => $version,
                 'versions' => Documentation::getDocVersions(),
-                'currentSection' => '',
+                'currentSection' => $otherVersions->isEmpty() ? '' : '/'.$page,
                 'canonical' => null,
             ], 404);
         }

--- a/resources/views/docs-missing.blade.php
+++ b/resources/views/docs-missing.blade.php
@@ -1,1 +1,14 @@
-Nothing to see here.
+<h1>Page not found</h1>
+
+@if($otherVersions->isEmpty())
+    <p>Nothing to see here.</p>
+@else
+    <p>This page does not exist in this version of Laravel but can be found in others.</p>
+    <div class="content-list">
+        <ul>
+            @foreach($otherVersions as $key => $title)
+                <li><a href="{{ url('/docs/'.$key.'/'.$page) }}">{{ $title }}</a></li>
+            @endforeach
+        </ul>
+    </div>
+@endif


### PR DESCRIPTION
There are a number of pages that have come and gone in the documentation's lifetime. There are dozens of examples I could list, but here's a few:

* 4.2 had a page on the [IoC container](https://laravel.com/docs/4.2/ioc) which was later renamed to the [Service Container
](https://laravel.com/docs/6.x/container).
* 5.0 to 5.3 had pages on [Elixir](https://laravel.com/docs/5.0/elixir) before that was renamed to [Mix](https://laravel.com/docs/6.x/mix).
* 5.1 and 5.2 included a [short tutorial](https://laravel.com/docs/5.1/quickstart) which was dropped from the documentation. 

This PR improves the 404 page by looking at other versions of the documentation and checking if the page existed in some other point in time. If it does, then links are included to those versions. If not, then current behaviour and message are displayed (with an added h1 Page Not Found title).

<img width="1205" alt="Screenshot 2020-01-26 at 00 10 03" src="https://user-images.githubusercontent.com/4213522/73128960-53ce5500-3fd0-11ea-928a-60f67ba5d240.png">

