### PR TITLE
max height increased for footer nav contain

### DIFF
--- a/resources/sass/_footer.scss
+++ b/resources/sass/_footer.scss
@@ -261,7 +261,7 @@ footer {
         }
         
         .footer_nav_contain {
-            max-height: 33em;
+            max-height: 34em;
         }
     }
     


### PR DESCRIPTION
Footer ecosystem column max-height set to 33rem. In Firefox 73.0 on macOS telescope's half is not visible. You can see it in the attached file.

![Screen Shot 2020-02-12 at 15 17 12](https://user-images.githubusercontent.com/374634/74338883-0d406f00-4db4-11ea-8032-57f7b12309d4.png)

This PR fixes this problem increasing max-height to 34rem.