### PR TITLE
Remove blockquote horizontal margin on smaller screens

### DIFF
--- a/resources/sass/_typography.scss
+++ b/resources/sass/_typography.scss
@@ -169,6 +169,13 @@ q, blockquote {
     }
 }
 
+blockquote {
+    @include fl-break-max(40em) {
+        margin-left: 0;
+        margin-right: 0;
+    }
+}
+
 span.small_text {
     display: block;
     font-size: .625em;


### PR DESCRIPTION
[Inspiration](https://twitter.com/SadeghPM/status/1228190212158672896).

This PR removes horizontal margin of blockquote elements on smaller screen sizes thus increasing readability.

Breakpoint of 40em was chosen based on another usage of the `fl-break-max` mixin [here](https://github.com/laravel/laravel.com-next/blob/master/resources/sass/_docs.scss#L64). Added the changes to `_typography.scss` since I found other references to blockquote in that file.

Before (left) and after (right):
![image](https://user-images.githubusercontent.com/19325270/74543666-12cdbe80-4f46-11ea-913c-2aef3e61eaf3.png)

Have a great day!