### PR TITLE
Add 5.5 back (supported until Aug 2020)

### DIFF
--- a/build/docs.sh
+++ b/build/docs.sh
@@ -2,6 +2,7 @@
 base=/home/forge/laravel.com
 docs=${base}/resources/docs
 
+cd ${docs}/5.5 && git pull origin 5.5
 cd ${docs}/5.8 && git pull origin 5.8
 cd ${docs}/6.0 && git pull origin 6.0
 cd ${docs}/6.x && git pull origin 6.x

--- a/build/sami/sami.php
+++ b/build/sami/sami.php
@@ -14,9 +14,10 @@ $iterator = Finder::create()
 	->in($dir = __DIR__.'/laravel/src');
 
 $versions = GitVersionCollection::create($dir)
+	->add('5.5', 'Laravel 5.5')
 	->add('5.8', 'Laravel 5.8')
-    ->add('6.x', 'Laravel 6.x')
-    ->add('7.x', 'Laravel 7.x')
+	->add('6.x', 'Laravel 6.x')
+	->add('7.x', 'Laravel 7.x')
 	->add('master', 'Laravel Dev');
 
 return new Sami($iterator, array(


### PR DESCRIPTION
https://laravel.com/api/5.5/ was recently removed, but it should be available at least until August 2020 when it's LTS support ends.