### PR TITLE
Hide Laracon Online Feb 26 banner on homepage

### DIFF
--- a/resources/views/marketing.blade.php
+++ b/resources/views/marketing.blade.php
@@ -15,10 +15,10 @@
                             </div>
                             <div class="banner_content">
 <!--                                 <p class="small">Laravel Vapor is now available! Sign up today!
-                                    <span class="arrow">→</span></p> -->
+                                    <span class="arrow">→</span></p> 
 
                                 <p class="small">Laracon Online is February 26th. Get your tickets now!
-                                    <span class="arrow">→</span></p>
+                                    <span class="arrow">→</span></p>-->
                             </div>
                         </a>
                     </div>


### PR DESCRIPTION
I noticed the "Laracon Online is February 26th" banner was showing on the home page.  The update simply comments out the banner which looks to be how a prior banner was removed.  I figured this may help out. (Though not 100% sure this is the best workflow).  Keep up the great work!