### PR TITLE
fix hero banner on tablet

### DIFF
--- a/resources/sass/_pages.scss
+++ b/resources/sass/_pages.scss
@@ -84,3 +84,11 @@
 		}
 	}
 }
+
+.home {
+    @include fl-break-min-max(48em, 64em) {
+        .page_contain {
+            overflow: hidden;
+        }
+    }
+}


### PR DESCRIPTION
Fix hero banner on tablet home page
Before:
![before](https://user-images.githubusercontent.com/26163841/76677644-5bc27280-65d9-11ea-9ec9-37dbb6a7f332.jpg)


After:
![after](https://user-images.githubusercontent.com/26163841/76677645-60872680-65d9-11ea-818e-4945c8bed999.jpg)
