### PR TITLE
Add canonical link

### DIFF
--- a/resources/views/partials/layout.blade.php
+++ b/resources/views/partials/layout.blade.php
@@ -6,6 +6,10 @@
     <title>{{ isset($title) ? $title . ' - ' : null }}Laravel - The PHP Framework For Web Artisans</title>
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
 
+    @if (isset($canonical))
+    <link rel="canonical" href="{{ url($canonical) }}">
+    @endif
+
     <!-- Favicon -->
     <link rel="apple-touch-icon" sizes="180x180" href="/img/favicon/apple-touch-icon.png">
     <link rel="icon" type="image/png" sizes="32x32" href="/img/favicon/favicon-32x32.png">


### PR DESCRIPTION
This brings back the canonical link which was present in the previous version of the Laravel website:

https://github.com/laravel/laravel.com/blob/01c9b5a0cf969cba615eacb7f8af9dd9ed980321/resources/views/app.blade.php#L11-L13

Related to: https://twitter.com/stoicseal/status/1244426084776624135