### PR TITLE
Update latest version link to redirect to the same section

### DIFF
--- a/resources/views/docs.blade.php
+++ b/resources/views/docs.blade.php
@@ -60,7 +60,7 @@
 
                                         <p class="content">
                                             <strong>WARNING</strong> You're browsing the documentation for an old version of Laravel.
-                                            Consider upgrading your project to <a href="{{ route('docs.version', DEFAULT_VERSION) }}">Laravel {{ DEFAULT_VERSION }}</a>.
+                                            Consider upgrading your project to <a href="{{ route('docs.version', [DEFAULT_VERSION, ltrim($currentSection, '/')]) }}">Laravel {{ DEFAULT_VERSION }}</a>.
                                         </p>
                                     </div>
                                 </blockquote>


### PR DESCRIPTION
The current latest version link always redirect the base page `/docs/7.x/`

With this PR, it will redirect from `/docs/5.8/valet` to `/docs/7.x/valet` not to `/docs/7.x/` – just like the behavior of the top-right dropdown.
