### PR TITLE
Modify warning link to point to the current page latest version instead of the installation page

### DIFF
--- a/app/Http/Controllers/DocsController.php
+++ b/app/Http/Controllers/DocsController.php
@@ -69,6 +69,7 @@ class DocsController extends Controller
                 'versions' => Documentation::getDocVersions(),
                 'currentSection' => $otherVersions->isEmpty() ? '' : '/'.$page,
                 'canonical' => null,
+                'page' => null,
             ], 404);
         }
 
@@ -96,6 +97,7 @@ class DocsController extends Controller
             'versions' => Documentation::getDocVersions(),
             'currentSection' => $section,
             'canonical' => $canonical,
+            'page' => $page,
         ]);
     }
 

--- a/resources/views/docs.blade.php
+++ b/resources/views/docs.blade.php
@@ -60,7 +60,7 @@
 
                                         <p class="content">
                                             <strong>WARNING</strong> You're browsing the documentation for an old version of Laravel.
-                                            Consider upgrading your project to <a href="{{ route('docs.version', DEFAULT_VERSION) }}">Laravel {{ DEFAULT_VERSION }}</a>.
+                                            Consider using <a href="{{ route('docs.version', ['version' => DEFAULT_VERSION, 'page' => $page]) }}">Laravel {{ DEFAULT_VERSION }}</a>.
                                         </p>
                                     </div>
                                 </blockquote>


### PR DESCRIPTION
The goal of this PR is to enhance the user experience for many documentation readers:

Here is a typical scenario:
- A user clicks on a Laravel documentation link about  "csrf" found on the web: [CSRF Protection](https://laravel.com/docs/7.x/csrf).
- The link turns out to be from a previous version, the user sees the version warning: 
> You're browsing the documentation for an old version of Laravel. Consider upgrading your project to [Laravel 8.x](https://laravel.com/docs/8.x).

- The user clicks on [Laravel 8.x](https://laravel.com/docs/8.x) and gets to the installation page.

Since the user clicked on a documentation link about "csrf", maybe, the user wanted to know more about csrf in Laravel's current version and it would be convenient to look at it in one click.

The versions dropdown does the same thing but clicking in the link is quicker.

This PR brings this minor feature. The idea is to tell the user: "Hey, that's an old version, here is a new one"

I hope this makes sense.

Have a nice day.
