### PR TITLE
Fix the `<code>` tag overflow on mobile resolution

### DIFF
--- a/resources/css/_prism.css
+++ b/resources/css/_prism.css
@@ -63,10 +63,10 @@ pre[class*="language-"] {
 }
 
 .docs_main :not(pre) > code {
-		display: inline-flex;
+    display: inline-flex;
     padding: 0 .125rem;
-		max-width: 100%;
-		overflow-x: scroll;
+    max-width: 100%;
+    overflow-x: scroll;
 }
 
 .token.comment,

--- a/resources/css/_prism.css
+++ b/resources/css/_prism.css
@@ -63,8 +63,10 @@ pre[class*="language-"] {
 }
 
 .docs_main :not(pre) > code {
+		display: inline-flex;
     padding: 0 .125rem;
-    display: inline-block;
+		max-width: 100%;
+		overflow-x: scroll;
 }
 
 .token.comment,


### PR DESCRIPTION
## Issue
The `<code>` tag causes a horizontal scroll on mobile devices when its content is too long (eg: [Sanctum documentation page](https://laravel.test/docs/8.x/sanctum)). See the screenshot above:
<img width="350" alt="horizontal-scroll" src="https://user-images.githubusercontent.com/11693661/104035755-cbda5e80-51d2-11eb-9911-20669c35adcf.png">


## Fix
I added CSS attributes to the tag being careful not to break the alignment with the rest of the textual content.