### PR TITLE
Switch cloning docs to http

### DIFF
--- a/bin/checkout_latest_docs.sh
+++ b/bin/checkout_latest_docs.sh
@@ -20,9 +20,9 @@ DOCS_VERSIONS=(
 for v in "${DOCS_VERSIONS[@]}"; do
     if [ -d "resources/docs/$v" ]; then
         echo "Pulling latest documentation updates for $v..."
-        (cd resources/docs/$v && git pull)
+        (cd resources/docs/"$v" && git pull)
     else
         echo "Cloning $v..."
-        git clone --single-branch --branch "$v" git@github.com:laravel/docs.git "resources/docs/$v"
+        git clone --single-branch --branch "$v" https://github.com/laravel/docs.git "resources/docs/$v"
     fi;
 done


### PR DESCRIPTION
Not having git configured with ssh can cause cloning issues.

- replace ssh clone with http
- wrap $v var with double quote to prevent globbing and word splitting