### PR TITLE
Accessibility: skip-to-content link in docs

### DIFF
--- a/resources/css/_accessibility.css
+++ b/resources/css/_accessibility.css
@@ -1,0 +1,18 @@
+#skip-to-content-link:not(:focus) {
+    position: absolute !important;
+    clip: rect(0, 0, 0, 0) !important;
+    width: 1px !important;
+    height: 1px !important;
+    padding: 0 !important;
+    margin: -1px !important;
+    overflow: hidden !important;
+}
+
+#skip-to-content-link {
+    z-index: 2147483647;
+}
+
+#main-content {
+    outline: none;
+}
+

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -7,6 +7,7 @@
 @import "./_sidebar_layout.css";
 @import "./_docs.css";
 @import "./_carbon_ads.css";
+@import "./_accessibility.css";
 
 @import 'tailwindcss/utilities';
 

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -6,4 +6,5 @@ document.addEventListener('DOMContentLoaded', () => {
     if (document.querySelector('#docsScreen')) {
         require('./docs.js');
     }
+    require('./components/accessibility');
 });

--- a/resources/js/components/accessibility.js
+++ b/resources/js/components/accessibility.js
@@ -1,0 +1,25 @@
+const skipToContentLink = document.querySelector('#skip-to-content-link');
+const mainContentWrapper = document.querySelector('#main-content');
+
+if (skipToContentLink && mainContentWrapper) {
+    skipToContentLink.addEventListener('click', setFocusOnContentWrapper);
+    mainContentWrapper.addEventListener('blur', removeContentWrapperTabIndex);
+}
+
+if (skipToContentLink && !mainContentWrapper) {
+    removeSkipToContentLink();
+}
+
+function setFocusOnContentWrapper(e) {
+    e.preventDefault();
+    mainContentWrapper.setAttribute('tabindex', -1);
+    mainContentWrapper.focus();
+}
+
+function removeContentWrapperTabIndex() {
+    mainContentWrapper.removeAttribute('tabindex');
+}
+
+function removeSkipToContentLink() {
+    skipToContentLink.parentNode.removeChild(skipToContentLink);
+}

--- a/resources/views/components/accessibility/main-content-wrapper.blade.php
+++ b/resources/views/components/accessibility/main-content-wrapper.blade.php
@@ -1,0 +1,3 @@
+<div id="main-content">
+    {{ $slot }}
+</div>

--- a/resources/views/components/accessibility/skip-to-content-link.blade.php
+++ b/resources/views/components/accessibility/skip-to-content-link.blade.php
@@ -1,0 +1,7 @@
+<a
+    id="skip-to-content-link"
+    href="#main-content"
+    class="absolute bg-gray-100 px-4 py-2 top-3 left-3 text-gray-700 shadow-xl"
+>
+    Skip to content
+</a>

--- a/resources/views/docs.blade.php
+++ b/resources/views/docs.blade.php
@@ -1,6 +1,7 @@
 @extends('partials.layout')
 
 @section('content')
+    <x-accessibility.skip-to-content-link />
     <div class="relative overflow-auto" id="docsScreen">
         <div class="relative lg:flex lg:items-start">
             <aside
@@ -188,8 +189,9 @@
                                     </div>
                                 </blockquote>
                             @endif
-
-                            {!! $content !!}
+                            <x-accessibility.main-content-wrapper>
+                                {!! $content !!}
+                            </x-accessibility.main-content-wrapper>
                         </section>
                     </section>
                 </div>


### PR DESCRIPTION
The link allows screen readers and keyboard users to quickly jump over the main navigation. It's a recommended accessibility feature from the [Web Content Accessibility Guidelines 2.1, Section 2.4.1: Bypass Blocks](https://www.w3.org/WAI/WCAG21/Understanding/bypass-blocks.html). I primarily navigate the web with my keyboard, so this would save me from hitting the tab key a bunch of times on the docs page.

## Before
The user currently must tab through ~90 elements before arriving at the main content. Check the bottom left corner of the gif below to see the links that are being tabbed through.
![before skip-to-content link](https://user-images.githubusercontent.com/26637919/111242539-9da34180-85bc-11eb-98f2-64625369f905.gif)

## After
The link only appears when it has focus, allowing the user to bypass the main navigation.
![after skip-to-content link](https://user-images.githubusercontent.com/26637919/111242576-aac03080-85bc-11eb-93ef-ac32ae0bff47.gif)

If this request is accepted, I'd like to add this feature to the site's other pages. I've left the other pages off of this pull request because the diff would have been very large.