### PR TITLE
Redirect to current section from "old version" warning

### DIFF
--- a/resources/views/docs.blade.php
+++ b/resources/views/docs.blade.php
@@ -164,7 +164,7 @@
 
                                         <p class="mb-0 lg:ml-4">
                                             <strong>WARNING</strong> You're browsing the documentation for an old version of Laravel.
-                                            Consider upgrading your project to <a href="{{ route('docs.version', DEFAULT_VERSION) }}">Laravel {{ DEFAULT_VERSION }}</a>.
+                                            Consider upgrading your project to <a href="{{ route('docs.version', DEFAULT_VERSION) . $currentSection }}">Laravel {{ DEFAULT_VERSION }}</a>.
                                         </p>
                                     </div>
                                 </blockquote>


### PR DESCRIPTION
This PR modifies the url inside "You're browsing the documentation for an old version of Laravel" warning card to always redirect to the current section of the docs.

**Why?**

Very frequently I google a specific section of the docs and often the first search result is a link to an older version of Laravel. I always assume the link is going to take me to the current section but instead I get redirected to the default page and I have to find the section manually, which can be a super frustrating experience. 
