### PR TITLE
Fix code tags alignment on browsers that use different default baseline

### DIFF
--- a/resources/css/_prism.css
+++ b/resources/css/_prism.css
@@ -67,6 +67,7 @@ pre[class*="language-"] {
     padding: 0 .125rem;
     max-width: 100%;
     overflow-x: auto;
+    vertical-align: middle;
 }
 
 .token.comment,


### PR DESCRIPTION
Follow-up to #153 (and the subsequent #154).

On browser Pale Moon, the code tags are shifted up, which makes reading the documentation quite tedious. That seems to be because Pale Moon applies a different default baseline, closer to the specifications, than Firefox and Chrome.

For more details you may read [this topic](https://forum.palemoon.org/viewtopic.php?f=70&t=26935) on Pale Moon forum.

